### PR TITLE
Add Italian localization for LazTekDev

### DIFF
--- a/GameData/LazTek/LazTekDev/Localization/it-it.cfg
+++ b/GameData/LazTek/LazTekDev/Localization/it-it.cfg
@@ -1,0 +1,95 @@
+it-it.cfg
+
+// it-it.cfg v1.3.1.0
+// LazTek Dev (LTD)
+// created: 13 Dec 2022
+// updated: 17 Mar 2023
+
+// THIS FILE:
+//   CC BY-SA 4.0 by zer0Kerbal
+//   translated by [zer0Kerbal](https://github.com/zer0Kerbal)
+//   italian translation by: [alessiagallerani-commits](https://github.com/alessiagallerani-commits)
+
+Localization
+{
+	it-it
+	{
+	// Agemt
+		#LTD-Agency-titl = LazTek Development
+		#LTD-Agency-desc = Temporal Anomolies. Ad do magna dolore elit veniam Lorem amet.
+		#LTD-Agency-descR = Aliqua minim officia minim eiusmod quis. Id non ad adipisicing Lorem eiusmod ad duis laboris amet laboris id amet consectetur. Excepteur sit quis aliqua. Officia magna aute occaecat qui elit qui mollit dolor culpa. Labore fugiat laboris anim minim est laboris culpa enim labore id do do. Nisi culpa nulla eiusmod culpa ipsum tempor in consequat ipsum velit sint enim esse occaecat deserunt. Non enim nulla consectetur ipsum. Ut sit aliquip mollit sunt occaecat ea qui proident sint nostrud magna eiusmod.
+		#LTD-tags = laztek development ltd
+
+	// Part Tags
+		#LTD-eng-draco = motore super draco
+
+	// Actions
+		#LTD-MAG-lab-strt = Cupola: Espandi
+		#LTD-MAG-lab-stop = Cupola: Riduci
+		#LTD-MAG-lab-actn = Attiva/Disattiva Cupola
+
+		#LTD-MAG-hab-strt = Habitat: Espandi
+		#LTD-MAG-hab-stop = Habitat: Riduci
+		#LTD-MAG-hab-actn = Attiva/Disattiva Habitat
+
+		#LTD-MAG-lad-strt = Estendi Scaletta
+		#LTD-MAG-lad-stop = Ritrai Scaletta
+		#LTD-MAG-lad-actn = Attiva/Disattiva Scaletta
+
+		#LTD-MAG-lights-strt = Accendi Luci
+		#LTD-MAG-lights-stop = Spegni Luci
+		#LTD-MAG-lights-actn = Attiva/Disattiva Luci
+
+		#LTD-MAG-lights-int-strt = Accendi Luci cabina
+		#LTD-MAG-lights-int-stop = Spegni Luci cabina
+		#LTD-MAG-lights-int-actn = Attiva/Disattiva Luci cabina
+
+		#LTD-MAG-lights-ext-strt = Accendi Luci Esterne
+		#LTD-MAG-lights-ext-stop = Spegni Luci Esterne
+		#LTD-MAG-lights-ext-actn = Attiva/Disattiva Luci esterne
+
+		#LTD-MAG-lights-dock-strt = Accendi Luci di attracco
+		#LTD-MAG-lights-dock-stop = Spegni Luci di attracco
+		#LTD-MAG-lights-dock-actn = Attiva/Disattiva Luci di attracco
+
+		#LTD-MAG-lights-blue-strt = Accendi Luci Blu
+		#LTD-MAG-lights-blue-stop = Spegni Luci Blu
+		#LTD-MAG-lights-blue-actn = Attiva/Disattiva Luci blu
+
+		#LTD-MAG-fin-grid-strt = Dispiega Alette a griglia
+		#LTD-MAG-fin-grid-stop = Ritrai Alette a griglia
+		#LTD-MAG-fin-grid-actn = Attiva/Disattiva Alette a griglia
+
+		#LTD-MAG-leg-strt = Dispiega Gamba
+		#LTD-MAG-leg-stop = Ritrai Gamba
+		#LTD-MAG-leg-actn = Attiva/Disattiva Gambe
+
+		#LTD-MAG-hatch-strt = Apri Portello
+		#LTD-MAG-hatch-stop = Chiudi Portello
+		#LTD-MAG-hatch-actn = Attiva/Disattiva Portello
+
+		#LTD-MAG-cover-strt = Apri Coperture Solari
+		#LTD-MAG-cover-stop = Chiudi Coperture Solari
+		#LTD-MAG-cover-actn = Attiva/Disattiva Coperture solari
+
+		#LTD-MAG-cargo-strt = Apri Vano Carico
+		#LTD-MAG-cargo-stop = Chiudi Vano Carico
+		#LTD-MAG-cargo-actn = Attiva/Disattiva Vano carico
+
+		#LTD-MAG-intake-strt = Apri Cono di Prua
+		#LTD-MAG-intake-stop = Chiudi Cono di Prua
+		#LTD-MAG-intake-actn = Attiva/Disattiva Cono di prua
+
+		#LTD-MAG-umbilical-strt = Collega Ombelicale
+		#LTD-MAG-umbilical-stop = Scollega Ombelicale
+		#LTD-MAG-umbilical-actn = Attiva/Disattiva ombelicale
+
+		#LTD-MAG-VTOL-strt = Spinta a Sinistra
+		#LTD-MAG-VTOL-stop = Spinta Indietro
+		#LTD-MAG-VTOL-actn = Attiva/Disattiva Spinta a sinistra
+
+		#LTD-MAG-VTOR-strt = Spinta a Destra
+		#LTD-MAG-VTOR-stop = Spinta Indietro
+		#LTD-MAG-VTOR-actn = Attiva/Disattiva Spinta a destra
+	}
+}

--- a/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
@@ -1,13 +1,13 @@
 ---
-permalink: /Quickstart-it.html
+permalink: /quickstart-it.html
 title: Guida rapida per iniziare
 ---
 
 <!--
-quickstart.md v1.0.1.1
-Progetto di Localizzazione
-creato: 01 Gen 2018
-aggiornato: 20 Mag 2022
+quickstart-it.md v1.0.1.1
+Localization project
+created: 01 Jen 2018
+updated: 20 May 2022
 
 -->
 

--- a/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
@@ -6,7 +6,7 @@ title: Guida rapida per iniziare
 <!--
 quickstart-it.md v1.0.1.1
 Localization project
-created: 01 Jen 2018
+created: 01 Jan 2018
 updated: 20 May 2022
 
 -->

--- a/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
@@ -37,7 +37,7 @@ Per creare una traduzione per la tua lingua, fai una copia del file *en_us.cfg* 
 
 Ci sono alcuni caratteri speciali che non devono essere tradotti in altre lingue e vanno mantenuti nel file così come sono.
 
-1. i tag non vanno rimpiazzati. Invece i tag nella nuova lingua vanno aggiunti.
+1. i tag esistenti non vanno rimpiazzati. Invece i tag nella nuova lingua vanno aggiunti in coda.
 2. le sequenze di controllo come '\n', '\t' o simili.
 3. i tag HTML come  `<b>...</b>, <i>...</i>` o simili.
 

--- a/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/quickstart-it.md
@@ -1,0 +1,44 @@
+---
+permalink: /Quickstart-it.html
+title: Guida rapida per iniziare
+---
+
+<!--
+quickstart.md v1.0.1.1
+Progetto di Localizzazione
+creato: 01 Gen 2018
+aggiornato: 20 Mag 2022
+
+-->
+
+## Guida alla traduzione
+
+Se desideri aiutare a tradurre questa mod, lo apprezzo davvero molto! Segui questa rapida guida per iniziare.
+
+### Come tradurre
+
+Per creare una traduzione per la tua lingua, fai una copia del file *en_us.cfg* e rinomina il file secondo la tua lingua:
+
+* *es-es.cfg* per lo Spagnolo
+* *es-mx.cfg* per lo Spagnolo Messicano
+* *ja.cfg* per il Giapponese
+* *ru.cfg* per il Russo
+* *zh-cn.cfg* per il Cinese semplificato
+
+*Ricapitolando:*
+
+* *es-es* per lo Spagnolo
+* *es-mx* per lo Spagnolo Messicano
+* *ja* per il Giapponese
+* *ru* per il Russo
+* *zh-cn* per il Cinese semplificato
+
+### Cosa non tradurre
+
+Ci sono alcuni caratteri speciali che non devono essere tradotti in altre lingue e vanno mantenuti nel file così come sono.
+
+1. i tag non vanno rimpiazzati. Invece i tag nella nuova lingua vanno aggiunti.
+2. le sequenze di controllo come '\n', '\t' o simili.
+3. i tag HTML come  `<b>...</b>, <i>...</i>` o simili.
+
+<!-- CC BY-ND-4.0 by zer0Kerbal  -->

--- a/GameData/LazTek/LazTekDev/Localization/readme-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/readme-it.md
@@ -4,7 +4,7 @@ title: Istruzioni per la localizzazione e la traduzione
 ---
 <!-- readme-it.md v2.1.2.0
 Localization project
-created: 01 Jen 2018
+created: 01 Jan 2018
 updated: 13 May 2022  -->
 
 <!--da: @HebruSan (grazie) ![link](https://github.com/HebaruSan/Astrogator/tree/master/assets/lang)  -->

--- a/GameData/LazTek/LazTekDev/Localization/readme-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/readme-it.md
@@ -2,10 +2,10 @@
 permalink: /readme-it.html
 title: Istruzioni per la localizzazione e la traduzione
 ---
-<!-- readme.md v2.1.2.0
-Progetto di localizzazione
-creato: 01 Gen 2018
-aggiornato: 13 Mag 2022  -->
+<!-- readme-it.md v2.1.2.0
+Localization project
+created: 01 Jen 2018
+updated: 13 May 2022  -->
 
 <!--da: @HebruSan (grazie) ![link](https://github.com/HebaruSan/Astrogator/tree/master/assets/lang)  -->
 

--- a/GameData/LazTek/LazTekDev/Localization/readme-it.md
+++ b/GameData/LazTek/LazTekDev/Localization/readme-it.md
@@ -1,0 +1,166 @@
+---
+permalink: /readme-it.html
+title: Istruzioni per la localizzazione e la traduzione
+---
+<!-- readme.md v2.1.2.0
+Progetto di localizzazione
+creato: 01 Gen 2018
+aggiornato: 13 Mag 2022  -->
+
+<!--da: @HebruSan (grazie) ![link](https://github.com/HebaruSan/Astrogator/tree/master/assets/lang)  -->
+
+# Tradurre nella tua lingua
+![Lingue supportate da KSP 1.3: Inglese, Spagnolo, Cinese, Russo, Giapponese](https://i.imgur.com/DbCCJWK.png)
+
+La versione 1.3 di KSP introduce la localizzazione, che consente al testo in gioco di essere tradotto in altre lingue. Questo permette a più persone di utilizzare il gioco nella lingua che preferiscono e di allargare la community. Nonostante ciò, questo non accade automaticamente per le mod; di default, una mod appare in inglese perché è la lingua base del gioco. Per avere sia il gioco base sia le modifiche disponibili nella stessa lingua che non è l'inglese, è necessario lavoro extra da parte del modder.
+
+Sfortunatamente parlo solo inglese e mantengo questa mod gratuitamente. Ciò significa che non posso essere io a fare le traduzioni e non posso pagare un servizio di traduzione professionale per avere traduzioni di qualità. Il meglio che posso fare da solo è usare Google Traduttore, che è di dubbio valore per le frasi brevi e idiomatiche che servono per la UI delle mod di KSP. Di conseguenza, mi affido a voi che siete esperti, gli utenti multilingue delle mod KSP, per dirmi quali sono le traduzioni migliori per la vostra lingua. Se desideri aiutare in questo lavoro, allora ti consiglio di continuare a leggere per capire come sono strutturati i file linguistici della mod e come inviare le traduzioni in modo che siano utilizzabili da altri.
+
+Nota: Anche se ti sembrerà di modificare i file di progetto, non preoccuparti di commettere errori. GitHub manterrà separate le tue modifiche dai file principali fino a che non avrò verificato che siano pronti e corretti per essere utilizzati. Inoltre è possibile che io faccia domande o richieda modifiche prima che il tuo lavoro sia trasferito sui file principali.
+
+## Lingue
+
+* Supportate da Kerbal Space Program a partire da 1.12.x
+  * ![English][EN] Inglese <en-us.cfg>
+  * ![Brasil][BR] Brasiliano <pt-br.cfg>
+  * ![中文][CN] Cinese semplificato (中文) <zh-cn.cfg>
+  * ![Deutsch][DE] Tedesco (Deutsch) <de.cfg>
+  * ![Español][ES] Spagnolo (Español) <es-es.cfg>
+  * ![Français][FR] Francese (Français)<fr-fr.cfg>
+  * ![Italiano][IT] Italiano (Italiano) <it-it.cfg>
+  * ![日本語][JA] Giapponese (日本語) <ja.cfg>
+* Incluse
+  * ![한국어][KO] Coreano (한국어) <ko.cfg>
+  * ![Español Mexicano][MX] Spagnolo Messicano (Español Mexicano) <es-mx.cfg>
+  * ![Dutch][NL] Olandese <nl-nl.cfg>
+  * ![Norsk][NO] Norvegese (Norsk) <no-no.cfg>
+  * ![Polski][PO] Polacco (Polski) <pl.cfg>
+  * ![Русский][RU] Russo (Русский) <ru.cfg>
+  * ![Svenska][SW] Svedese (Svenska) <sw-sw.cfg>
+  * ![国语][TW] Thailandese (国语) <zh-tw.cfg>
+
+## Creare o modificare una traduzione
+
+È consigliato effettuare inizialmente le tue modifiche sul tuo computer così che tu possa testarle prima di caricarle, specialmente se stai facendo una traduzione da zero.
+
+1. Se non lo hai già fatto installa la versione corrente della xxx mod
+2. Apri la tua cartella `<KSP_ROOT>/GameData/xxxMod/Localization` sul tuo disco locale
+3. Cerca un file chiamato *lang*.cfg, dove *lang* è il nome di KSP in locale; per KSP 1.3, questo include:
+
+* en-us (English)
+* es-es (Spanish)
+* ja (Japanese)
+* ru (Russian)
+* zh-cn (Chinese)
+
+I prossimi passi sono diversi a seconda che il file sia già esistente o meno:
+
+### Se il file esiste
+
+Segui questi passi per migliorare una traduzione esistente:
+
+4. Modifica il file relativo alla tua lingua nell'editor di testo che preferisci
+5. Fai le modifiche che desideri vedere in gioco (vedi la [Sezione Formato File](#formato-file) sottostante per i dettagli)
+6. Salva le tue modifiche
+7. Ricorda di [testare le tue modifiche](#testing)!
+
+### Se il file non esiste
+
+Segui questi passi per iniziare la tua traduzione da zero:
+
+4. Fai una copia di `en-us.cfg` nella cartella `Localization`
+5. Rinomina il file seguendo la lista di lingue qui sopra
+6. Modifica il file per la tua lingua nel tuo editor di testo preferito 
+7. Cambia la terza riga da `en-us` nella frase per la tua lingua (vedi la [Sezione Lingue](#lingue) per i dettagli)
+8. Traduci ogni frase dall'inglese nella tua lingua (vedi la [Sezione Formato File](#formato-file) sottostante per i dettagli)
+9. Salva le tue modifiche 
+10. Ricorda di [testare le tue modifiche](#testing)!
+
+### Formato File
+
+La parte centrale del file `cfg` contiene le frasi da tradurre. Il formato è  `parola = traduzione`, dove la parola è una frase specifica definita dalla mod. Per esempio:
+
+    #launchSubtitle = Transfers from <<1>>\n(Launch ~<<2>>)
+
+**NON** modificare la parte a sinistra del simbolo uguale ("=")! Queste parole devono essere le stesse in ogni file in lingua.
+
+La parte a destra del simbolo uguale è la frase da utilizzare in gioco. La maggior parte del testo sarà mostrata così com'è, però potrebbero essere presenti alcuni elementi speciali come mostrato in [Lingoona grammar module demo](http://lingoona.com/cgi-bin/grammar#l=en&oh=1):
+
+| Elemento| Significato                                                                                                                |
+| ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| \n      | Interruzione di riga; cerca di preservarle basandoti sulla frase originale per essere sicuro che la frase sia compatibile  |
+| <<1>>   | Il primo token sostituibile nella stringa, sarà sostituito da un numero, il nome di un pianeta, ecc., in base alla stringa  |
+| <<2>>   | Secondo token, e così via                                                                                                  |
+| <<A:1>> | Il primo token, ma sostituito dal giusto articolo                                                                          |
+
+Per esempio, questa è una possibile traduzione della riga sopra in Spagnolo, fatta da Google Traduttore:
+
+    #launchSubtitle = Transferencias desde <<1>>\n(Lanzamiento ~<<2>>)
+
+### Testing
+
+È importante assicurarsi che le modifiche al lavoro siano corrette. Se usi Steam:  
+1. [Seleziona la lingua da usare in Steam](https://www.youtube.com/watch?v=iBwYCvQxfeI)
+2. Attendi che il download del pacchetto linguistico sia completato
+3. Esegui KSP
+4. Utilizza la xxxMod in gioco e assicurati che i tuoi cambiamenti appaiano correttamente
+
+Se non usi Steam, non conosco i passaggi per scegliere la lingua. Contatta SQUAD nel caso tu abbia difficoltà.
+
+## Rendere disponibile la tua traduzione per l'utilizzo da parte di altri
+
+Dopo aver preparato un file `cfg` per la tua lingua e confermato che funzioni correttamente, se decidi di renderlo disponibile per la ridistribuzione sotto la licenza della xxxMod, segui questi passaggi per caricarlo per essere incluso nella distribuzione della mod principale:
+
+1. Accedi a [GitHub](https://github.com); potresti dover registrare un account se non ne possiedi già uno
+2. Apri la cartella Localization per la xxxMod
+3. Cerca il file che hai modificato
+
+I restanti passaggi sono diversi a seconda che il file esista o meno:
+
+### Se il file esiste
+
+4. Fai click sul nome del file per visionarlo
+5. Premi [l'icona della matita](https://help.github.com/assets/images/help/repository/edit-file-edit-button.png) per modificare
+6. Rimpiazza il testo con il contenuto copiato del file che hai modificato localmente
+7. **Importante**: Alla fine della pagina, sotto a Proponi una modifica al file, scrivi una descrizione in inglese delle modifiche effettuate e le ragioni che le giustificano. Questo mi aiuterà a confermare che le tue modifiche siano appropriate. Ricorda che non parlo la lingua del file `cfg`, quindi ho bisogno che tu mi spieghi perché le tue scelte sono le migliori!
+8. Quando hai finito fai click su `Propose file change` alla fine della pagina
+
+### Se il file non esiste
+
+4. Fai click su [Crea nuovo file](https://help.github.com/assets/images/help/repository/create_new_file.png) per crearlo
+5. Inserisci il nome del file corretto nel box sopra
+6. Copia i contenuti del file modificato localmente nel grande box al centro
+7. Quando hai finito premi `Propose new file` alla fine della pagina
+
+### Revisione
+
+Una volta terminate le modifiche, GitHub mi invierà una notifica che è stata inviata una 'pull request'. Darò un'occhiata al lavoro nel giro di un giorno o due e verificherò che le modifiche siano coerenti, in questo modo:
+
+* Confermando che il nome del file e la terza riga del file siano coerenti con uno dei nomi supportati in locale
+* Visionando in gioco ogni frase modificata
+* Controllando con Google Traduttore
+* Chiedendo a persone esperte
+* Chiedendo aiuto al forum di KSP
+
+Se avrò qualunque domanda riguardo ad una modifica specifica effettuata, le aggiungerò alla 'pull request', così dovrebbe arrivarti una notifica. Cerca per favore di rispondere in tempo utile. La tua 'pull request' potrà essere chiusa senza che le modifiche siano incluse, se non riceverò risposta per un lungo periodo.
+
+Una volta che tutte le domande e i commenti saranno risolti secondo i miei standard, le tue modifiche saranno inserite nei file principali e incluse nel prossimo rilascio. Inoltre aggiungerò il tuo nome di GitHub alla sezione dei ringraziamenti ai collaboratori del file README.
+
+[EN]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/EN.png "English"  
+[BR]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/BR.png "Português Brasil"
+[CN]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/CH.png "中文"  
+[DE]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/DE.png "Deutsch"  
+[ES]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/ES.png "Español"  
+[FR]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/FR.png "Français"  
+[IT]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/IT.png "Italiano"  
+[JA]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/JA.png "日本語"  
+[KO]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/KO.png "한국어"  
+[MX]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/MX.png "Mexicano Español"  
+[NL]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/NL.png "Dutch"  
+[NO]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/NO.png "Norsk"
+[PO]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/PO.png "Polski"  
+[RU]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/RU.png "Русский"  
+[SW]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/SW.png "Svenska"  
+[TW]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/img/TW.png "国语"
+
+<!-- CC BY-ND 4.0 by zer0Kerbal  -->


### PR DESCRIPTION
Hi,
I added the Italian translation file (_it-it.cfg_) and the translation for the _readme_ and _quickstart_ file. 
Regarding the _quickstart_ and _readme_ file translation, I tried to follow the syntactic structure of your writing. I maintained the first person paragraphs in first person in Italian, and I also translated the language lists across every file. 

Since I don't have the game installed, I couldn't test the _it-it.cfg_ in-game, but I tried to fit it into the standard  video game UI conventions.
A few notes on my choices for the _it-it.cfg_ file:
- I left the Latin placeholders untouched.
- I changed the syntactic English structure from Subject- Object- Predicate to the Italian Subject-Predicate-Object flow. 
-  I used the imperative mood for verbs instead of the infinitive one (like in English) to follow how usually commands work in Italian games
- I also noticed a probable typo at line 90 (VTOR section), where in the original version it says "Left Thrust", but since the key is for Right, I considered it as "Right Thrust" and translated it accordingly.


Let me know if everything looks good or if you need any adjustments. Hope it helps! 
